### PR TITLE
Fix cross-chart axis labels

### DIFF
--- a/assets/charts/donorLocation/donorLocation.js
+++ b/assets/charts/donorLocation/donorLocation.js
@@ -244,8 +244,8 @@
 
       // Update the scale and label on y axis.
       setYFormat();
-      d3.selectAll('.y.axis').call(yAxis);
-      d3.selectAll('.y.axis .label').text(yLabel());
+      d3.select(chartEl).selectAll('.y.axis').call(yAxis)
+        .selectAll('.label').text(yLabel());
 
       // Update the stacked bars.
       rectangles = rectangles.data(rectangleData);


### PR DESCRIPTION
Updated d3 selectors so that changing the labels on one chart doesn't mess with the labels on another.
