### PR TITLE
Fixed user reload window bug to direct user back to home page

### DIFF
--- a/assets/js/views/candidate.js
+++ b/assets/js/views/candidate.js
@@ -22,8 +22,12 @@ OpenDisclosure.CandidateView = Backbone.View.extend({
      "),
 
   initialize: function(){
-    this.model.attributes.imagePath = this.model.imagePath();
-    this.render();
+    if (this.model) {
+      this.model.attributes.imagePath = this.model.imagePath();
+      this.render();}
+    else { 
+      app.navigate('home',true)
+    }
   },
 
   render: function(){


### PR DESCRIPTION
all candidate links working after page reload

```
* if candidate model is not accessible in candidate view it navigates back to home page
* could be way to keep state on candidate page after reload, but don't know how, will fix if I figure it out
* all links at least work after window reload
```
