### PR TITLE
Fix reload of candidates

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,6 +1,6 @@
 OpenDisclosure.App = Backbone.Router.extend({
   routes: {
-    '/': 'home',
+    '': 'home',
     'about': 'about',
     'candidate/:id': 'candidate',
     'contributor/:id': 'contributor'
@@ -13,7 +13,6 @@ OpenDisclosure.App = Backbone.Router.extend({
     this.categoryContributions = new OpenDisclosure.CategoryContributions();
     this.whales = new OpenDisclosure.Whales();
     this.multiples = new OpenDisclosure.Multiples();
-    this.home();
   },
 
   home: function(){
@@ -37,7 +36,12 @@ OpenDisclosure.App = Backbone.Router.extend({
   },
 
   candidate: function(id){
-    new OpenDisclosure.CandidateView({model: this.candidates.get(id)});
+    if (this.candidates.loaded)
+      new OpenDisclosure.CandidateView({model: this.candidates.get(id)});
+    else
+      this.listenTo(this.candidates, 'sync', function() {
+	new OpenDisclosure.CandidateView({model: this.candidates.get(id)});
+      });
   },
 
   contributor : function(id) {

--- a/assets/js/collections/candidates.js
+++ b/assets/js/collections/candidates.js
@@ -3,5 +3,8 @@ OpenDisclosure.Candidates = Backbone.Collection.extend({
   model: OpenDisclosure.Candidate,
   initialize: function(){
     this.fetch();
+    this.listenTo(this, 'sync', function() {
+      this.loaded = true;
+    });
   }
 });

--- a/assets/js/views/candidate.js
+++ b/assets/js/views/candidate.js
@@ -28,7 +28,7 @@ OpenDisclosure.CandidateView = Backbone.View.extend({
       this.model.attributes.imagePath = this.model.imagePath();
       this.render();}
     else {
-      app.navigate('home',true);
+      app.navigate('',true);
     }
   },
 


### PR DESCRIPTION
This fixes the reload of the candidates page and other reload issues but removing the call to home in the initialize function and only calling the candidate view after the collection has loaded.
