### PR TITLE
Make all mathbars add up right

### DIFF
--- a/assets/css/main.css.scss
+++ b/assets/css/main.css.scss
@@ -361,11 +361,6 @@ header {
     font-size: 12px;
     letter-spacing: 0.5px;
     padding: 6px 12px;
-    width: 20%;
-
-    @include degrade(extra-small) {
-      width: 100%;
-    }
   }
 
   .money-number {

--- a/assets/js/models/candidate.js
+++ b/assets/js/models/candidate.js
@@ -7,25 +7,34 @@ OpenDisclosure.Candidate = Backbone.Model.extend({
     return this.attributes.image;
   },
 
+  totalContributions : function() {
+    return OpenDisclosure.friendlyMoney(this._totalContributionsRaw());
+  },
+
+  availableBalance : function() {
+    return OpenDisclosure.friendlyMoney(this.attributes.summary['ending_cash_balance'] -
+                                        this.attributes.summary['total_unpaid_bills']);
+  },
+
   pctContributionsFromOakland : function() {
-    return OpenDisclosure.friendlyPct(1 - this.attributes.received_contributions_from_oakland /
-                            this.attributes.received_contributions_count);
+    return OpenDisclosure.friendlyPct(this.attributes.received_contributions_from_oakland / this._totalContributionsRaw());
   },
 
   pctSmallContributions : function() {
-    return OpenDisclosure.friendlyPct((
-      this.attributes.small_contributions +
-         this.attributes.summary['total_unitemized_contributions']) /
-      this.attributes.summary['total_contributions_received']);
+    return OpenDisclosure.friendlyPct(
+      (this.attributes.summary['total_unitemized_contributions'] +
+       this.attributes.small_contributions) / this._totalContributionsRaw());
   },
 
   avgContribution : function () {
-    return OpenDisclosure.friendlyMoney(
-      this.attributes.summary['total_contributions_received']/
-      this.attributes.received_contributions_count);
+    return OpenDisclosure.friendlyMoney(this._totalContributionsRaw() / this.attributes.received_contributions_count);
   },
 
   friendlySummaryNumber : function(which) {
     return OpenDisclosure.friendlyMoney(this.attributes.summary[which]);
+  },
+
+  _totalContributionsRaw : function() {
+    return this.attributes.summary['total_contributions_received'] + this.attributes.summary['total_misc_increases_to_cash'];
   },
 });

--- a/assets/js/views/candidate.js
+++ b/assets/js/views/candidate.js
@@ -7,10 +7,9 @@ OpenDisclosure.Views.Candidate = Backbone.View.extend({
     <h1><%= candidate.get('short_name') %></h1>\
     <% if (candidate.get('summary') !== null) { %>\
       <section class='clearfix' id='mathbar'>\
-        <div class='col-sm-3 money-label'>Total Contributions <br><span class='money-number'><%= candidate.friendlySummaryNumber('total_contributions_received') %></span><span class='mathsign'>–</span></div>\
+        <div class='col-sm-3 money-label'>Total Contributions <br><span class='money-number'><%= candidate.totalContributions() %></span><span class='mathsign'>–</span></div>\
         <div class='col-sm-3 money-label'>Expenditures <br><span class='money-number'><%= candidate.friendlySummaryNumber('total_expenditures_made') %></span><span class='mathsign'>=</span></div>\
-        <div class='col-sm-3 money-label'>Cash On Hand <br><span class='money-number'><%= candidate.friendlySummaryNumber('ending_cash_balance') %></span><span class='mathsign'>+</span></div>\
-        <div class='col-sm-3 money-label'>Unpaid Bills <br><span class='money-number'><%= candidate.friendlySummaryNumber('NNN') %></span></div>\
+        <div class='col-sm-3 money-label'>Available Balance<br><span class='money-number'><%= candidate.availableBalance() %></span></div>\
         <div class='col-sm-3 money-label count'> No. of Contributions <br><span class='money-number'><%= candidate.get('received_contributions_count') %></span></div>\
       </section>\
     <% } %>\

--- a/backend/fetchers/summary.rb
+++ b/backend/fetchers/summary.rb
@@ -4,9 +4,12 @@ class DataFetcher
     # Form_Type => { Line_Item => SQL Column name }
     SUMMARY_LINES = {
       'F460' => {
-        '1'  => :total_monetary_contributions,
+        '3'  => :total_monetary_contributions,
+        '4'  => :total_nonmonetary_contributions,
         '5'  => :total_contributions_received,
+        '9'  => :total_unpaid_bills,
         '11' => :total_expenditures_made,
+        '14' => :total_misc_increases_to_cash,
         '16' => :ending_cash_balance,
       },
       'A' => {

--- a/backend/models/contribution.rb
+++ b/backend/models/contribution.rb
@@ -13,9 +13,9 @@ class Contribution < ActiveRecord::Base
   enum type: [:contribution, :loan, :inkind]
 
   def increment_oakland_contribution_count
-    if contributor.from_oakland?
-      Party.increment_counter(:received_contributions_from_oakland, recipient.id)
-    end
+    return unless contributor.from_oakland?
+    recipient.received_contributions_from_oakland += amount
+    recipient.save
   end
 
   def set_self_contribution

--- a/backend/schema.rb
+++ b/backend/schema.rb
@@ -58,11 +58,18 @@ ActiveRecord::Schema.define do
   create_table :summaries do |t|
     t.integer :party_id, null: false
     t.date :last_summary_date
-    t.integer :total_unitemized_contributions
+
+    # From Summary sheet:
     t.integer :total_monetary_contributions
+    t.integer :total_nonmonetary_contributions
     t.integer :total_contributions_received
+    t.integer :total_unpaid_bills
     t.integer :total_expenditures_made
+    t.integer :total_misc_increases_to_cash
     t.integer :ending_cash_balance
+
+    # From Schedule A summary:
+    t.integer :total_unitemized_contributions
 
     t.index :party_id, unique: true
   end

--- a/bin/test_amounts
+++ b/bin/test_amounts
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+load 'backend/environment.rb'
+
+Party.mayoral_candidates.each do |c|
+  puts c.short_name
+  contributions = c.summary.total_contributions_received
+  expenditures = c.summary.total_expenditures_made
+  misc = c.summary.total_misc_increases_to_cash
+  unpaid = c.summary.total_unpaid_bills
+  actual = c.summary.ending_cash_balance
+
+  total = contributions - expenditures + misc + unpaid
+
+  puts "contributions:    $#{contributions}"
+  puts "expenditures:   - $#{expenditures}"
+  puts "misc:           + $#{misc}"
+  puts "unpaid:         + $#{unpaid}"
+  puts "                ===================="
+  puts "                  $#{total}"
+  puts "actual COH:     - $#{actual}"
+  puts "                ===================="
+  puts "difference:       $#{total - actual}"
+  puts ''
+  puts ''
+end

--- a/views/index.haml
+++ b/views/index.haml
@@ -59,7 +59,7 @@
                     <th id='mayoral-table-name-column'></th>
                     <th class='mayoral-table-head bold'>Total Raised</th>
                     <th class='mayoral-table-head'>Number of itemized contributions</th>
-                    <th class='mayoral-table-head'>Percentage of # of itemized contributions from outside Oakland</th>
+                    <th class='mayoral-table-head'>Percentage of itemized contributions from Oakland*</th>
                     <th class='mayoral-table-head'>Percentage of Total Raised from small contributions*</th>
                     <th class='mayoral-table-head'>Average of itemized contributions</th>
                   </tr>
@@ -79,7 +79,7 @@
                         </div>
                       </td>
                       <% if (m.attributes.summary) { %>
-                        <td class='mayoral-table-number'><%= m.friendlySummaryNumber('total_contributions_received') %></td>
+                        <td class='mayoral-table-number'><%= m.totalContributions() %></td>
                         <td class='mayoral-table-number'><%= m.attributes.received_contributions_count %></td>
                         <td class='mayoral-table-number'><%= m.pctContributionsFromOakland() %></td>
                         <td class='mayoral-table-number'><%= m.pctSmallContributions() %></td>
@@ -93,7 +93,7 @@
                 </tbody>
               </table>
               <p>This table includes all candidates who have submitted campaign finance disclosure forms as of #{last_updated.strftime '%B %e, %Y'}.</p>
-              <h5> * Candidates do not need to itemize contributions less than $100, see the <a href='/faq#smallContributions'>FAQ</a> </h5>
+              <h5> * Candidates do not need to itemize contributions less than $100, <a href='/faq#smallContributions'>see the FAQ</a> </h5>
     %footer.main-footer
       %a{ href: 'http://codeforamerica.org/'}
         %img.footer-logos.CfA{ src: image_path('cfa_logo_footer.png') }


### PR DESCRIPTION
We have been grappling with data integrity problems. The primary reason
is that there are two factors that are included on one half of the
equation, but not the other:
1. Unpaid bills are counted as an "Expenditure" but do not subtract from
   "Cash on Hand"
2. Candidates can report "Miscellaneous Adjustments" which are things
   like interest, selling things for fair market value, or transfers from
   another committee by the name name.

These are accounted for in two ways:
1. Unpaid bills are subtracted from "Cash on Hand" to produce a new
   figure "Available Balance". This number more-accurately reflects a
   campaign's fiscal status and, if the candidate accrues too many
   unpaid bills, will be negative. I think a negative number reflects
   properly on the candidate's situation.
2. "Miscellaneous Adjustments" are all positive, and as such are
   income, so they are added to "Contributions". This isn't completely
   clean, but the amount of these are negligible.

This adds a bin/test_amounts script which performs the math in the
mathbar to see if it checks out.

@lla2105 @mikeubell @evanwolf @elinaru Does this sound good?
