### PR TITLE
Move footnotes above candidates without data.

### DIFF
--- a/views/index.haml
+++ b/views/index.haml
@@ -85,6 +85,9 @@
                   <% }); %>
                 </tbody>
               </table>
+              <p class='clearfix'>This table includes all candidates who have submitted campaign finance disclosure forms as of #{last_updated.strftime '%B %e, %Y'}.</p>
+              <h5> * This is the percentage of money, excluding candidates own contributions and non-itimized contributions </h5>
+              <h5> ** Candidates do not need to itemize contributions less than $100, <a href='/faq#smallContributions'>see the FAQ</a> </h5>
               <h3>Candidates Without Data:</h3>
               <p class='footnote'>These candidates will appear on the ballot in November, but have not filed any campaign finance disclosures.</p>
               <p class='footnote'>For more information on who must file disclosures <a href='/faq#whoMustFile'>see the FAQ</a>.</p>
@@ -101,9 +104,6 @@
                 </li>
               <% }); %>
               </ul>
-              <p class='clearfix'>This table includes all candidates who have submitted campaign finance disclosure forms as of #{last_updated.strftime '%B %e, %Y'}.</p>
-              <h5> * This is the percentage of money, excluding candidates own contributions and non-itimized contributions </h5>
-              <h5> ** Candidates do not need to itemize contributions less than $100, <a href='/faq#smallContributions'>see the FAQ</a> </h5>
     %footer.main-footer
       /
         Commented out as a reminder it would be cool to get CfA's logo on here for real.


### PR DESCRIPTION
These tend to get lost, so move them up.
