### PR TITLE
Move last updated information to the party

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -255,10 +255,14 @@ class OpenDisclosureApp < Sinatra::Application
   end
 
   get '*' do
+    most_recently_updated_party = Party.where('last_updated_date is not null')
+                                       .order(last_updated_date: :desc)
+                                       .first
+
     # This renders views/index.haml
     haml :index, locals: {
       candidates: Party.all_mayoral_candidates,
-      last_updated: Summary.order(:last_summary_date).last.last_summary_date,
+      last_updated: most_recently_updated_party.last_updated_date,
       candidate_json: candidate_json
     }
   end
@@ -269,7 +273,9 @@ class OpenDisclosureApp < Sinatra::Application
     fields = {
       only: %w[
         id name committee_id received_contributions_count contributions_count
-        received_contributions_from_oakland self_contributions_total small_contributions],
+        received_contributions_from_oakland self_contributions_total small_contributions
+        last_updated_date
+      ],
       methods: [
         :summary,
         :short_name,

--- a/assets/js/templates/candidate.hbs
+++ b/assets/js/templates/candidate.hbs
@@ -51,7 +51,7 @@
       <p>Personal funds loaned and contributed to campaign: {{friendlyMoney self_contributions_total}}</p>
       <p>% of the total amount raised is personal funds: {{summary.pctPersonalContributions}}</p>
       <p>Declared candidacy: {{declared}} </p>
-      <p>Data last updated: {{summary.lastSummaryDate}} </p>
+      <p>Data last updated: {{lastUpdatedDate}} </p>
       <p class='sources'>* Candidates do not need to itemize contributions less than $100 by contributor, but do need to include all contributions in their total reported amount.  <b><a href='/faq#smallContributions'>FAQ</a> </b></p>
     {{else}}
       <div class='noContributions'>The candidate had not reported any campaign contributions by the last filing deadline. Candidates are not required to report if they have raised less than $1,000.</div>

--- a/assets/js/views/candidate.js
+++ b/assets/js/views/candidate.js
@@ -102,9 +102,9 @@ OpenDisclosure.Views.Candidate = Backbone.View.extend({
     var context = _.clone(this.model.attributes);
 
     context.imagePath = this.model.imagePath();
+    context.lastUpdatedDate = this.model.get('last_updated_date');
 
     if (this.model.get('summary') !== null) {
-      context.summary.lastSummaryDate = this.model.get('summary').last_summary_date;
       context.summary.totalContributions = this.model.totalContributions();
       context.summary.availableBalance = this.model.availableBalance();
       context.summary.totalExpenditures = this.model.friendlySummaryNumber('total_expenditures_made');

--- a/backend/fetchers/lateContribution.rb
+++ b/backend/fetchers/lateContribution.rb
@@ -36,6 +36,9 @@ class DataFetcher
                       .tap { |p| p.update_attributes(city: row['enty_city'], state: row['enty_st'], zip: row['enty_zip4']) }
         end
 
+      ::Party.where(committee_id: row['filer_id'])
+             .update_all(['last_updated_date = GREATEST(?, last_updated_date)', row['rpt_date']])
+
       ::Contribution.create(
         recipient: recipient,
         contributor: contributor,

--- a/backend/fetchers/summary.rb
+++ b/backend/fetchers/summary.rb
@@ -40,14 +40,15 @@ class DataFetcher
       if column =~ /^total/
         summary.update_attributes(
           column => (summary[column] || 0) + value.to_i,
-          :last_summary_date => row['rpt_date']
         )
       else
         summary.update_attributes(
           column => value,
-          :last_summary_date => row['rpt_date']
         )
       end
+
+      ::Party.where(committee_id: row['filer_id'])
+             .update_all(['last_updated_date = GREATEST(?, last_updated_date)', row['rpt_date']])
 
       summary
     end

--- a/backend/schema.rb
+++ b/backend/schema.rb
@@ -21,9 +21,11 @@ ActiveRecord::Schema.define do
     t.integer :small_contributions, null: false, default: 0
     t.integer :contributions_count, null: false, default: 0
     t.integer :self_contributions_total, null: false, default: 0
+    t.date :last_updated_date
 
     t.index [:committee_id, :type]
     t.index [:type, :name, :city, :state]
+    t.index :last_updated_date
   end
 
   create_table :employers do |t|
@@ -57,7 +59,6 @@ ActiveRecord::Schema.define do
 
   create_table :summaries do |t|
     t.integer :party_id, null: false
-    t.date :last_summary_date
 
     # From Summary sheet:
     t.integer :total_monetary_contributions
@@ -73,6 +74,7 @@ ActiveRecord::Schema.define do
 
     t.index :party_id, unique: true
   end
+
   create_table :maps do |t|
     t.string :emp1, null: false
     t.string :emp2, null: false


### PR DESCRIPTION
We're displaying it on a per-candidate basis anyways, so this probably
makes sense to be on the `parties` table. Mainly instigated by the need
to account for Form 497 "Late" contributions.

Closes #289.

@mikeubell whaddya think?
